### PR TITLE
chore: nx migrate @nativescript/plugin-tools@3.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@angular/router": "^13.2.0",
     "@nativescript/angular": "^13.0.0",
     "@nativescript/core": "~8.2.0",
-    "@nativescript/plugin-tools": "3.0.0",
+    "@nativescript/plugin-tools": "3.0.3",
     "@nativescript/types": "~8.2.0",
     "@nativescript/webpack": "~5.0.5",
     "@ngtools/webpack": "^13.0.0",
@@ -47,3 +47,4 @@
     ]
   }
 }
+


### PR DESCRIPTION
From `@nativescript/plugin-tools@3.0.0` to `@nativescript/plugin-tools@3.0.3` the `add-package` generator has changed, migrating from `@nrwl/node:package` to `@nrwl/js:tsc`. However, there is no migration from 3.0.0 to 3.0.3. 

Hence, new devs using the seed will find that (1) adding a new package after using the template uses the old executor and (2) trying to build the newly added plugin will fail because the old executor is no longer accessible. (3) running `nx migrate @nativescript/plugin-tools` won't apply any migration, hence the new plugin build will remain broken.

This PR aims to mitigate this problem by updating the `@nativescript/plugin-tools` version so newly generated workspaces won't face this problem, but, a migration might still be needed.