### PR TITLE
fix: angular tsconfig wrong @demo/shared path

### DIFF
--- a/apps/demo-angular/tsconfig.json
+++ b/apps/demo-angular/tsconfig.json
@@ -1,9 +1,11 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
+    "rootDirs": [".", "../.."],
+    "baseUrl": ".",
     "paths": {
       "~/*": ["src/*"],
-      "@demo/shared": ["tools/demo/index.ts"]
+      "@demo/shared": ["../../tools/demo/index.ts"]
     }
   },
   "files": ["./references.d.ts", "./src/main.ts", "./src/polyfills.ts"],


### PR DESCRIPTION
# Error description

Angular demo build cannot find files under `@demo/shared` scope

# Steps to reproduce

1. Download plugin seed
2. Setup and config
3. Add a plugin
4. Try to build the Angular demo app
5. Webpack will fail with the following error:
![image](https://user-images.githubusercontent.com/10727467/159541362-ad919548-2739-4a34-89b6-ad64702f9f70.png)
