### PR TITLE
chore: bump compile and target sdk Android demo app versions

### DIFF
--- a/tools/assets/App_Resources/Android/app.gradle
+++ b/tools/assets/App_Resources/Android/app.gradle
@@ -5,14 +5,14 @@
 //	compile 'com.android.support:recyclerview-v7:+'
 //}
 
-android {  
-  compileSdkVersion 29
-  defaultConfig {  
+android {
+  compileSdkVersion 31
+  defaultConfig {
     minSdkVersion 21
-    targetSdkVersion 29
+    targetSdkVersion 31
     generatedDensities = []
-  }  
-  aaptOptions {  
-    additionalParameters "--no-version-vectors"  
-  }  
-} 
+  }
+  aaptOptions {
+    additionalParameters "--no-version-vectors"
+  }
+}


### PR DESCRIPTION
# Error description

It seems that latest version of `@nativescript/core widgets` depends on `androidx.fragment:fragment:1.4.1` which requires compileSdkVersion to be set to 31 or higher

# Steps to reproduce

1. Download plugin seed
2. Setup and config
3. Add a plugin
4. Try to build an Android demo (no matter the flavor)
5. Gradle will fail with the following error:
![image](https://user-images.githubusercontent.com/10727467/159543846-cc41667c-00aa-4ec6-ab5f-46ecdebbcfcf.png)


# Comments

I'm unsure this is the real fix to this, but for now, it fixes the problem and allows Android demos to compile again